### PR TITLE
fix: dtype issue with gemma3n

### DIFF
--- a/cut_cross_entropy/transformers/gemma3n.py
+++ b/cut_cross_entropy/transformers/gemma3n.py
@@ -178,7 +178,12 @@ def cce_forward_multimodal(
     if _PATCH_OPTS is not None and _PATCH_OPTS.use_lce(labels, self.training):
         assert labels is not None
         loss = apply_lce(
-            hidden_states[:, slice_indices, :],
+            # downcast hidden_states to match lm_head.weight dtype which should be bf16
+            (
+                hidden_states[:, slice_indices, :].to(self.lm_head.weight.dtype)
+                if hidden_states.dtype != self.lm_head.weight.dtype
+                else hidden_states[:, slice_indices, :]
+            ),
             self.lm_head.weight,
             labels,
             _PATCH_OPTS,


### PR DESCRIPTION
We need to add this temporary patch as `hidden_states` appear to be in `fp32`. This should be fixed in transformers.