### PR TITLE
fix: multiple return_dict error in gemma3n

### DIFF
--- a/cut_cross_entropy/transformers/gemma3n.py
+++ b/cut_cross_entropy/transformers/gemma3n.py
@@ -160,7 +160,7 @@ def cce_forward_multimodal(
         use_cache=use_cache,
         output_attentions=output_attentions,
         output_hidden_states=output_hidden_states,
-        return_dict=True,
+        # return_dict=True,  # will cause multiple return_dict error in self.model forward
         **lm_kwargs,
     )
 


### PR DESCRIPTION
Gemma3nConditionalGeneration passes `return_dict=True` to kwargs in Gemma3nModel. Then, the model also passes a second `return_dict=True`, so there's two kwargs with the same config.

https://github.com/huggingface/transformers/blob/67ddc82fbc7e52c6f42a395b4a6d278c55b77a39/src/transformers/models/gemma3n/modeling_gemma3n.py#L2324-L2326

https://github.com/huggingface/transformers/blob/67ddc82fbc7e52c6f42a395b4a6d278c55b77a39/src/transformers/models/gemma3n/modeling_gemma3n.py#L2150-L2153