### PR TITLE
handle when zero value numel() when using sequence-parallel

### DIFF
--- a/cut_cross_entropy/cce.py
+++ b/cut_cross_entropy/cce.py
@@ -146,7 +146,7 @@ class LinearCrossEntropyFunction(torch.autograd.Function):
         params = cast(CCEParams, ctx.params)
         reduction = params.reduction
         if reduction == "mean":
-            grad_scale = 1 / lse.numel()
+            grad_scale = 1 / lse.numel() if lse.numel() else 1.0
         elif reduction == "sum":
             grad_scale = 1.0
         elif reduction == "none":


### PR DESCRIPTION
User reported that using cce with sequence parallel training errored with:
```
[rank10]:   File "/root/miniconda3/envs/py3.11/lib/python3.11/site-packages/cut_cross_entropy/cce.py", line 149, in backward

[rank10]:     grad_scale = 1 / lse.numel()

[rank10]:                  ~~^~~~~~~~~~~~~

[rank10]: ZeroDivisionError: division by zero
```

this is likely because the process may have been filled with padding data that wasn't trainable, making numel() zero.