### PR TITLE
cast hidden states to same dtype as the weights for CCE+DoRA

### DIFF
--- a/cut_cross_entropy/transformers/llama.py
+++ b/cut_cross_entropy/transformers/llama.py
@@ -84,6 +84,9 @@ def cce_forward(
     )
 
     hidden_states = outputs.last_hidden_state
+    if self.lm_head.weight.dtype == torch.bfloat16 and hidden_states.dtype == torch.float32:
+        # specifically only handling the case we've seen with DoRA where it outputs float32 when the weights are bfloat16
+        hidden_states = hidden_states.to(self.lm_head.weight.dtype)
 
     loss = None
     logits = None

--- a/cut_cross_entropy/transformers/llama.py
+++ b/cut_cross_entropy/transformers/llama.py
@@ -84,9 +84,6 @@ def cce_forward(
     )
 
     hidden_states = outputs.last_hidden_state
-    if self.lm_head.weight.dtype == torch.bfloat16 and hidden_states.dtype == torch.float32:
-        # specifically only handling the case we've seen with DoRA where it outputs float32 when the weights are bfloat16
-        hidden_states = hidden_states.to(self.lm_head.weight.dtype)
 
     loss = None
     logits = None

--- a/cut_cross_entropy/transformers/utils.py
+++ b/cut_cross_entropy/transformers/utils.py
@@ -69,6 +69,10 @@ def apply_lce(
         # handle Tensor Parallelism
         c = c.to_local()
 
+    if c.dtype == torch.bfloat16 and e.dtype == torch.float32:
+        # specifically only handling the case we've seen with DoRA where it outputs float32 when the weights are bfloat16
+        e = e.to(c.dtype)
+
     loss = linear_cross_entropy(
         e,
         c,


### PR DESCRIPTION
Fixes https://github.com/axolotl-ai-cloud/axolotl/issues/2847 where DoRA outputs end up with float32 hidden states and breaks CCE

Let's only handle this case for now rather than blindly casting mismatched types.