### PR TITLE
handle tf32 api deprecation

### DIFF
--- a/cut_cross_entropy/cce_backward.py
+++ b/cut_cross_entropy/cce_backward.py
@@ -293,6 +293,10 @@ def _cce_back_block_d(args) -> int:
     block_d = args["BLOCK_D"]
     return 2 * block_d
 
+try:
+    USE_TF32 = torch.get_float32_matmul_precision() == "high"
+except RuntimeError:
+    USE_TF32 = torch.backends.cuda.matmul.fp32_precision == "tf32" or torch.backends.fp32_precision == "tf32"
 
 _cce_backward_kernel = triton.jit(_cce_backward_kernel)
 _cce_backward_kernel = triton.heuristics(  # type: ignore
@@ -313,9 +317,7 @@ _cce_backward_kernel = triton.heuristics(  # type: ignore
         "KAHAN_E": lambda args: args["dEC"] is not None,
         "KAHAN_C": lambda args: args["dCC"] is not None,
         "COMPUTE_DBIAS": lambda args: args["dBias"] is not None,
-        "DOT_PRECISION": lambda args: "tf32"
-        if torch.get_float32_matmul_precision() == "high"
-        else "ieee",
+        "DOT_PRECISION": lambda args: "tf32" if USE_TF32 else "ieee"
     }
 )(_cce_backward_kernel)
 _cce_backward_kernel = cce_backward_autotune()(_cce_backward_kernel)  # type: ignore

--- a/cut_cross_entropy/cce_lse_forward.py
+++ b/cut_cross_entropy/cce_lse_forward.py
@@ -117,6 +117,11 @@ def _cce_lse_forward_kernel(
     tl.atomic_xchg(this_locks, 0)
 
 
+try:
+    USE_TF32 = torch.get_float32_matmul_precision() == "high"
+except RuntimeError:
+    USE_TF32 = torch.backends.cuda.matmul.fp32_precision == "tf32" or torch.backends.fp32_precision == "tf32"
+
 _cce_lse_forward_kernel = triton.jit(_cce_lse_forward_kernel)
 _cce_lse_forward_kernel = triton.heuristics(  # type: ignore
     {
@@ -126,9 +131,7 @@ _cce_lse_forward_kernel = triton.heuristics(  # type: ignore
         "HAS_SOFTCAP": lambda args: args["softcap"] is not None,
         "HAS_LA": lambda args: args["LA"] is not None,
         "GROUP_B": lambda args: 8,
-        "DOT_PRECISION": lambda args: "tf32"
-        if torch.get_float32_matmul_precision() == "high"
-        else "ieee",
+        "DOT_PRECISION": lambda args: "tf32" if USE_TF32 else "ieee"
     }
 )(_cce_lse_forward_kernel)
 _cce_lse_forward_kernel = cce_forward_autotune()(_cce_lse_forward_kernel)  # type: ignore


### PR DESCRIPTION
When using torch 2.9, I'm getting this error:

```
  File "/root/miniconda3/envs/py3.11/lib/python3.11/site-packages/cut_cross_entropy/cce_lse_forward.py", line 130, in 
  <lambda>                                                                                                                                   if 
  torch.get_float32_matmul_precision() == "high"                                                                                                                                                                                                        
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                                                                                                                    

  File "/root/miniconda3/envs/py3.11/lib/python3.11/site-packages/torch/__init__.py", line 1551, in 
  get_float32_matmul_precision                                                                                                                             
  
    return _C._get_float32_matmul_precision()                                                                                                                                                                                                                           
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                                                                                                                

  RuntimeError: PyTorch is checking the matmul precision without a specific backend name,Current status indicate that you have used mix of the legacy and new APIs to set the matmul precision. We suggest only using the new API for matmul precision. See also: https://pytorch.org/docs/main/notes/cuda.html#tensorfloat-32-tf32-on-ampere-and-later-devices      
```