### PR TITLE
add zero3 support

### DIFF
--- a/cut_cross_entropy/cce.py
+++ b/cut_cross_entropy/cce.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2024 Apple Inc. All Rights Reserved.
-from dataclasses import dataclass
+from contextlib import nullcontext
+from dataclasses import dataclass, field
 from typing import cast
 
 import torch
@@ -35,6 +36,7 @@ class CCEParams:
     filter_e_grad: bool
     filter_c_grad: bool
     vocab_parallel_options: VocabParallelOptions | None
+    zero3_params: list[torch.nn.Parameter] = field(default_factory=list)
 
 
 @torch.compile(fullgraph=True)
@@ -174,26 +176,44 @@ class LinearCrossEntropyFunction(torch.autograd.Function):
             reduce_e_grad = vp_opts.reduce_e_grad
             pg = vp_opts.group
 
-        de, dc, dbias = cce_backward_kernel(
-            do=grad_out,
-            e=e,
-            c=c,
-            bias=bias,
-            lse=lse,
-            valids=valids,
-            softcap=params.softcap,
-            filter_eps=params.filter_eps,
-            targets=targets,
-            shift=params.shift,
-            vocab_ordering=vocab_ordering,
-            grad_scale=grad_scale,
-            accum_e_fp32=params.accum_e_fp32,
-            accum_c_fp32=params.accum_c_fp32,
-            filter_e_grad=params.filter_e_grad,
-            filter_c_grad=params.filter_c_grad,
-            reduce_e_grad=reduce_e_grad,
-            pg=pg,
-        )
+        # Under DeepSpeed ZeRO-3, saved tensors for c/bias may be stale
+        # local shards. Re-gather the full parameters before backward.
+        if params.zero3_params:
+            from deepspeed.runtime.zero.partition_parameters import GatheredParameters
+
+            gather_ctx = GatheredParameters(params.zero3_params, modifier_rank=None)
+        else:
+            gather_ctx = nullcontext()
+
+        with gather_ctx:
+            if params.zero3_params:
+                # After gathering, read the full weight/bias from the
+                # parameter objects since the saved tensor references
+                # point to the (now-stale) local shards.
+                c = params.zero3_params[0].data
+                if len(params.zero3_params) > 1:
+                    bias = params.zero3_params[1].data
+
+            de, dc, dbias = cce_backward_kernel(
+                do=grad_out,
+                e=e,
+                c=c,
+                bias=bias,
+                lse=lse,
+                valids=valids,
+                softcap=params.softcap,
+                filter_eps=params.filter_eps,
+                targets=targets,
+                shift=params.shift,
+                vocab_ordering=vocab_ordering,
+                grad_scale=grad_scale,
+                accum_e_fp32=params.accum_e_fp32,
+                accum_c_fp32=params.accum_c_fp32,
+                filter_e_grad=params.filter_e_grad,
+                filter_c_grad=params.filter_c_grad,
+                reduce_e_grad=reduce_e_grad,
+                pg=pg,
+            )
 
         return de, dc, dbias, None
 
@@ -230,6 +250,7 @@ def cce_linear_cross_entropy(
     filter_e_grad: bool = True,
     filter_c_grad: bool = True,
     vocab_parallel_options: VocabParallelOptions | None = None,
+    zero3_params: list[torch.nn.Parameter] | None = None,
 ) -> torch.Tensor:
     assert e.size()[0:-1] == targets.size()
     assert e.size(-1) == c.size(1)
@@ -267,6 +288,7 @@ def cce_linear_cross_entropy(
         filter_e_grad=filter_e_grad and filter_eps is not None,
         filter_c_grad=filter_c_grad and filter_eps is not None,
         vocab_parallel_options=vocab_parallel_options,
+        zero3_params=zero3_params or [],
     )
 
     return linear_cross_entropy_apply(e, c, bias, cce_params)

--- a/cut_cross_entropy/linear_cross_entropy.py
+++ b/cut_cross_entropy/linear_cross_entropy.py
@@ -53,6 +53,7 @@ def linear_cross_entropy(
     filter_c_grad: bool = True,
     impl: str | LinearCrossEntropyImpl = LCE_IMPL_DEFAULT,
     vocab_parallel_options: VocabParallelOptions | None = None,
+    zero3_params: list[torch.nn.Parameter] | None = None,
 ) -> torch.Tensor:
     """
     :param impl: The linear cross entropy implementation to use. Currently supports cce, torch_compile, and cce_exact.
@@ -109,6 +110,7 @@ def linear_cross_entropy(
             shift,
             **cce_opts,
             vocab_parallel_options=vocab_parallel_options,
+            zero3_params=zero3_params,
         )
     elif impl == "torch_compile":
         return torch_compile_linear_cross_entropy(

--- a/cut_cross_entropy/transformers/utils.py
+++ b/cut_cross_entropy/transformers/utils.py
@@ -134,6 +134,17 @@ def apply_lce(
     else:
         c_local = c
 
+    # Under DeepSpeed ZeRO-3, lm_head.weight is sharded across ranks.
+    # Pass the original nn.Parameter references so the backward pass can
+    # re-gather the full tensors via GatheredParameters.
+    zero3_params: list[torch.nn.Parameter] = []
+    if hasattr(c, "ds_id"):
+        zero3_params.append(c)
+    if bias is not None and hasattr(bias, "ds_id"):
+        zero3_params.append(bias)
+    if zero3_params:
+        cce_kwargs["zero3_params"] = zero3_params
+
     if c.dtype == torch.bfloat16 and e.dtype == torch.float32:
         # specifically only handling the case we've seen with DoRA where it outputs float32 when the weights are bfloat16
         e = e.to(c.dtype)


### PR DESCRIPTION
```
cut_cross_entropy/cce_backward.py", line 347, in cce_backward_kernel                                                                                                   
[rank0]:     assert c.size(1) == e.size(1)                                                                                                                                                                                                                   
[rank0]:            ^^^^^^^^^                                                                                                 
[rank0]: IndexError: Dimension out of range (expected to be in range of [-1, 0], but got 1)      
```
fixes issue with sharded lm_head