### PR TITLE
fix: align CCE patches with transformers 5.12.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ my_scripts/
 .model_cache/
 
 venv/
+build/

--- a/cut_cross_entropy/transformers/gemma3n.py
+++ b/cut_cross_entropy/transformers/gemma3n.py
@@ -1,4 +1,4 @@
-"""Gemma3n CCE patch. Adapted from transformers 4.56.2."""
+"""Gemma3n CCE patch. Adapted from transformers 5.12.1."""
 
 # Copyright (C) 2024 Apple Inc. All Rights Reserved.
 
@@ -21,7 +21,6 @@ from typing import Optional, Union
 
 import torch
 import transformers
-from torch import nn
 from transformers.cache_utils import Cache
 from transformers.modeling_outputs import CausalLMOutputWithPast
 from transformers.models.gemma3n.modeling_gemma3n import (
@@ -197,29 +196,12 @@ def cce_forward_multimodal(
             logits = logits * final_logit_softcapping
 
         if labels is not None:
-            # Upcast to float if we need to compute the loss to avoid potential precision issues
-            logits = logits.float()
-            shift_logits = logits[..., :-1, :]
-            shift_labels = labels[..., 1:]
-            if attention_mask is not None:
-                # we use the input attention mask to shift the logits and labels, because it is 2D.
-                # we also crop attn mask in case it is longer, which happens in PrefixTuning with peft
-                shift_attention_mask = attention_mask[:, -shift_logits.shape[1] :].to(logits.device)
-                shift_logits = shift_logits[
-                    shift_attention_mask.to(logits.device) != 0
-                ].contiguous()
-                shift_labels = shift_labels[
-                    shift_attention_mask.to(shift_labels.device) != 0
-                ].contiguous()
-            else:
-                shift_logits = shift_logits.contiguous()
-                shift_labels = shift_labels.contiguous()
-            # Flatten the tokens
-            loss_fct = nn.CrossEntropyLoss()
-
-            flat_logits = shift_logits.view(-1, self.config.text_config.vocab_size)
-            flat_labels = shift_labels.view(-1).to(shift_logits.device)
-            loss = loss_fct(flat_logits, flat_labels)
+            loss = self.loss_function(
+                logits=logits,
+                labels=labels,
+                vocab_size=self.config.get_text_config().vocab_size,
+                **lm_kwargs,
+            )
 
     return Gemma3nCausalLMOutputWithPast(
         loss=loss,

--- a/cut_cross_entropy/transformers/gemma4.py
+++ b/cut_cross_entropy/transformers/gemma4.py
@@ -192,6 +192,7 @@ def cce_forward_multimodal(
         attentions=outputs.attentions,
         image_hidden_states=outputs.image_hidden_states,
         audio_hidden_states=outputs.audio_hidden_states,
+        shared_kv_states=outputs.shared_kv_states,
     )
 
 

--- a/cut_cross_entropy/transformers/gemma4.py
+++ b/cut_cross_entropy/transformers/gemma4.py
@@ -1,4 +1,4 @@
-"""Gemma4 CCE patch. Gemma4 text inherits Gemma3. Adapted from transformers 5.5.0."""
+"""Gemma4 (text and multimodal) CCE patch. Adapted from transformers 5.12.1."""
 
 # Copyright (C) 2024 Apple Inc. All Rights Reserved.
 
@@ -21,7 +21,6 @@ from typing import Optional, Union
 
 import torch
 import transformers
-from torch import nn
 from transformers.cache_utils import Cache
 from transformers.models.gemma4.modeling_gemma4 import (
     Gemma4CausalLMOutputWithPast,
@@ -35,6 +34,75 @@ from cut_cross_entropy.transformers.utils import (
 )
 
 _PATCH_OPTS: PatchOptions | None = None
+
+
+def cce_forward(
+    self,
+    input_ids: Optional[torch.LongTensor] = None,
+    attention_mask: Optional[torch.Tensor] = None,
+    position_ids: Optional[torch.LongTensor] = None,
+    past_key_values: Optional[Cache] = None,
+    inputs_embeds: Optional[torch.FloatTensor] = None,
+    labels: Optional[torch.LongTensor] = None,
+    use_cache: Optional[bool] = None,
+    logits_to_keep: Union[int, torch.Tensor] = 0,
+    per_layer_inputs: Optional[torch.Tensor] = None,
+    **kwargs,
+) -> Gemma4CausalLMOutputWithPast:
+    # decoder outputs consists of (dec_features, layer_state, dec_hidden, dec_attn)
+    outputs = self.model(
+        input_ids=input_ids,
+        attention_mask=attention_mask,
+        position_ids=position_ids,
+        past_key_values=past_key_values,
+        inputs_embeds=inputs_embeds,
+        per_layer_inputs=per_layer_inputs,
+        use_cache=use_cache,
+        **kwargs,
+    )
+
+    hidden_states = outputs.last_hidden_state
+    loss = None
+    logits = None
+
+    # Only compute necessary logits, and do not upcast them to float if we are not computing the loss
+    slice_indices = (
+        slice(-logits_to_keep, None) if isinstance(logits_to_keep, int) else logits_to_keep
+    )
+
+    if _PATCH_OPTS is not None and _PATCH_OPTS.use_lce(labels, self.training):
+        assert labels is not None
+        loss = apply_lce(
+            hidden_states[:, slice_indices, :],
+            self.lm_head.weight,
+            labels,
+            _PATCH_OPTS,
+            softcap=self.config.final_logit_softcapping,
+            **kwargs,
+        )
+    else:
+        logits = self.lm_head(hidden_states[:, slice_indices, :])
+        if self.config.final_logit_softcapping is not None:
+            logits = logits / self.config.final_logit_softcapping
+            logits = torch.tanh(logits)
+            logits = logits * self.config.final_logit_softcapping
+
+        if labels is not None:
+            loss = self.loss_function(
+                logits=logits,
+                labels=labels,
+                vocab_size=self.config.vocab_size,
+                **kwargs,
+            )
+
+    return Gemma4CausalLMOutputWithPast(
+        loss=loss,
+        logits=logits,
+        past_key_values=outputs.past_key_values,
+        hidden_states=outputs.hidden_states,
+        attentions=outputs.attentions,
+        shared_kv_states=outputs.shared_kv_states,
+    )
 
 
 def cce_forward_multimodal(
@@ -54,6 +122,7 @@ def cce_forward_multimodal(
     labels: Optional[torch.LongTensor] = None,
     use_cache: Optional[bool] = None,
     logits_to_keep: Union[int, torch.Tensor] = 0,
+    per_layer_inputs: Optional[torch.Tensor] = None,
     **lm_kwargs,
 ) -> Gemma4CausalLMOutputWithPast:
     # Strip PEFT-injected return_dict so it doesn't collide with the explicit return_dict=True below.
@@ -70,6 +139,7 @@ def cce_forward_multimodal(
         past_key_values=past_key_values,
         mm_token_type_ids=mm_token_type_ids,
         inputs_embeds=inputs_embeds,
+        per_layer_inputs=per_layer_inputs,
         labels=labels,
         use_cache=use_cache,
         image_position_ids=image_position_ids,
@@ -107,29 +177,12 @@ def cce_forward_multimodal(
             logits = logits * final_logit_softcapping
 
         if labels is not None:
-            # Upcast to float if we need to compute the loss to avoid potential precision issues
-            logits = logits.float()
-            shift_logits = logits[..., :-1, :]
-            shift_labels = labels[..., 1:]
-            if attention_mask is not None:
-                # we use the input attention mask to shift the logits and labels, because it is 2D.
-                # we also crop attn mask in case it is longer, which happens in PrefixTuning with peft
-                shift_attention_mask = attention_mask[:, -shift_logits.shape[1] :].to(logits.device)
-                shift_logits = shift_logits[
-                    shift_attention_mask.to(logits.device) != 0
-                ].contiguous()
-                shift_labels = shift_labels[
-                    shift_attention_mask.to(shift_labels.device) != 0
-                ].contiguous()
-            else:
-                shift_logits = shift_logits.contiguous()
-                shift_labels = shift_labels.contiguous()
-            # Flatten the tokens
-            loss_fct = nn.CrossEntropyLoss()
-
-            flat_logits = shift_logits.view(-1, self.config.text_config.vocab_size)
-            flat_labels = shift_labels.view(-1).to(shift_logits.device)
-            loss = loss_fct(flat_logits, flat_labels)
+            loss = self.loss_function(
+                logits=logits,
+                labels=labels,
+                vocab_size=self.config.get_text_config().vocab_size,
+                **lm_kwargs,
+            )
 
     return Gemma4CausalLMOutputWithPast(
         loss=loss,
@@ -147,10 +200,8 @@ def patch_gemma4_text(
     patch_options: PatchOptions,
     remote_model_id: str | None = None,
 ) -> TransformersModelT | None:
-    from . import gemma3 as gemma3_patch
-
-    gemma3_patch._PATCH_OPTS = patch_options
-    cce_forward = gemma3_patch.cce_forward
+    global _PATCH_OPTS
+    _PATCH_OPTS = patch_options
 
     if remote_model_id is not None:
         patch_remote_model_class(

--- a/cut_cross_entropy/transformers/glm46v.py
+++ b/cut_cross_entropy/transformers/glm46v.py
@@ -1,4 +1,4 @@
-"""GLM46V CCE patch. GLM46V inherits GLM4V. Adapted from transformers 5.0.0."""
+"""GLM46V CCE patch. GLM46V inherits GLM4V. Adapted from transformers 5.12.1."""
 
 # Copyright (C) 2024 Apple Inc. All Rights Reserved.
 

--- a/cut_cross_entropy/transformers/glm4v.py
+++ b/cut_cross_entropy/transformers/glm4v.py
@@ -1,4 +1,4 @@
-"""GLM4V CCE patch. Adapted from transformers v4.56.2"""
+"""GLM4V CCE patch. Adapted from transformers 5.12.1."""
 
 # Copyright (C) 2024 Apple Inc. All Rights Reserved.
 
@@ -24,6 +24,10 @@ import transformers
 from transformers.models.glm4v.modeling_glm4v import (
     Glm4vCausalLMOutputWithPast,
 )
+from transformers.models.glm4v_moe.modeling_glm4v_moe import (
+    Glm4vMoeCausalLMOutputWithPast,
+    load_balancing_loss_func,
+)
 
 from cut_cross_entropy.transformers.utils import (
     PatchOptions,
@@ -47,8 +51,7 @@ def cce_forward_multimodal(
     pixel_values_videos: Optional[torch.FloatTensor] = None,
     image_grid_thw: Optional[torch.LongTensor] = None,
     video_grid_thw: Optional[torch.LongTensor] = None,
-    rope_deltas: Optional[torch.LongTensor] = None,
-    cache_position: Optional[torch.LongTensor] = None,
+    mm_token_type_ids: Optional[torch.IntTensor] = None,
     logits_to_keep: Union[int, torch.Tensor] = 0,
     **kwargs,
 ) -> Union[tuple, Glm4vCausalLMOutputWithPast]:
@@ -58,11 +61,11 @@ def cce_forward_multimodal(
         pixel_values_videos=pixel_values_videos,
         image_grid_thw=image_grid_thw,
         video_grid_thw=video_grid_thw,
+        mm_token_type_ids=mm_token_type_ids,
         position_ids=position_ids,
         attention_mask=attention_mask,
         past_key_values=past_key_values,
         inputs_embeds=inputs_embeds,
-        cache_position=cache_position,
         **kwargs,
     )
 
@@ -88,7 +91,7 @@ def cce_forward_multimodal(
 
         if labels is not None:
             loss = self.loss_function(
-                logits=logits, labels=labels, vocab_size=self.config.vocab_size
+                logits=logits, labels=labels, vocab_size=self.config.text_config.vocab_size
             )
 
     return Glm4vCausalLMOutputWithPast(
@@ -98,6 +101,86 @@ def cce_forward_multimodal(
         hidden_states=outputs.hidden_states,
         attentions=outputs.attentions,
         rope_deltas=outputs.rope_deltas,
+    )
+
+
+def cce_forward_multimodal_moe(
+    self,
+    input_ids: Optional[torch.LongTensor] = None,
+    attention_mask: Optional[torch.Tensor] = None,
+    position_ids: Optional[torch.LongTensor] = None,
+    past_key_values: Optional[list[torch.FloatTensor]] = None,
+    inputs_embeds: Optional[torch.FloatTensor] = None,
+    labels: Optional[torch.LongTensor] = None,
+    pixel_values: Optional[torch.Tensor] = None,
+    pixel_values_videos: Optional[torch.FloatTensor] = None,
+    image_grid_thw: Optional[torch.LongTensor] = None,
+    video_grid_thw: Optional[torch.LongTensor] = None,
+    mm_token_type_ids: Optional[torch.IntTensor] = None,
+    logits_to_keep: Union[int, torch.Tensor] = 0,
+    **kwargs,
+) -> Union[tuple, Glm4vMoeCausalLMOutputWithPast]:
+    outputs = self.model(
+        input_ids=input_ids,
+        pixel_values=pixel_values,
+        pixel_values_videos=pixel_values_videos,
+        image_grid_thw=image_grid_thw,
+        video_grid_thw=video_grid_thw,
+        position_ids=position_ids,
+        attention_mask=attention_mask,
+        past_key_values=past_key_values,
+        inputs_embeds=inputs_embeds,
+        mm_token_type_ids=mm_token_type_ids,
+        **kwargs,
+    )
+
+    hidden_states = outputs[0]
+    logits = None
+    loss = None
+
+    # Only compute necessary logits, and do not upcast them to float if we are not computing the loss
+    slice_indices = (
+        slice(-logits_to_keep, None) if isinstance(logits_to_keep, int) else logits_to_keep
+    )
+
+    if _PATCH_OPTS is not None and _PATCH_OPTS.use_lce(labels, self.training):
+        assert labels is not None
+        loss = apply_lce(
+            hidden_states[:, slice_indices, :],
+            self.lm_head.weight,
+            labels,
+            _PATCH_OPTS,
+        )
+    else:
+        logits = self.lm_head(hidden_states[:, slice_indices, :])
+
+        if labels is not None:
+            loss = self.loss_function(
+                logits=logits, labels=labels, vocab_size=self.config.text_config.vocab_size
+            )
+
+    aux_loss = None
+    if kwargs.get("output_router_logits", False):
+        aux_loss = load_balancing_loss_func(
+            outputs.router_logits,
+            self.num_experts,
+            self.num_experts_per_tok,
+            attention_mask,
+        )
+        if labels is not None:
+            loss += self.config.text_config.router_aux_loss_coef * aux_loss.to(
+                loss.device
+            )  # make sure to reside in the same device
+
+    return Glm4vMoeCausalLMOutputWithPast(
+        loss=loss,
+        aux_loss=aux_loss,
+        logits=logits,
+        past_key_values=outputs.past_key_values,
+        hidden_states=outputs.hidden_states,
+        attentions=outputs.attentions,
+        rope_deltas=outputs.rope_deltas,
+        router_logits=outputs.router_logits,
     )
 
 
@@ -143,7 +226,7 @@ def patch_glm4v_moe(
         patch_remote_model_class(
             remote_model_id=remote_model_id,
             class_name="Glm4vMoeForConditionalGeneration",
-            patch_fn=cce_forward_multimodal,
+            patch_fn=cce_forward_multimodal_moe,
         )
         return None
 
@@ -153,8 +236,8 @@ def patch_glm4v_moe(
         assert isinstance(maybe_model, modeling_glm4v_moe.Glm4vMoeForConditionalGeneration), (
             f"Expected a Glm4vMoeForConditionalGeneration model. Got {type(maybe_model)}."
         )
-        maybe_model.forward = MethodType(cce_forward_multimodal, maybe_model)
+        maybe_model.forward = MethodType(cce_forward_multimodal_moe, maybe_model)
         return maybe_model
 
-    modeling_glm4v_moe.Glm4vMoeForConditionalGeneration.forward = cce_forward_multimodal
+    modeling_glm4v_moe.Glm4vMoeForConditionalGeneration.forward = cce_forward_multimodal_moe
     return None

--- a/cut_cross_entropy/transformers/glm_moe_dsa.py
+++ b/cut_cross_entropy/transformers/glm_moe_dsa.py
@@ -1,4 +1,4 @@
-"""GLM MoE DSA (GLM-5) CCE patch. GLM MoE DSA inherits GLM4 MoE which inherits Llama. Adapted from transformers 5.2.0."""
+"""GLM MoE DSA (GLM-5) CCE patch. GlmMoeDsaForCausalLM -> DeepseekV32ForCausalLM -> Llama. Adapted from transformers 5.12.1."""
 
 # Copyright (C) 2024 Apple Inc. All Rights Reserved.
 

--- a/cut_cross_entropy/transformers/lfm2_moe.py
+++ b/cut_cross_entropy/transformers/lfm2_moe.py
@@ -1,4 +1,4 @@
-"""Lfm2Moe CCE patch. Lfm2Moe inherits Mixtral. Adapted from transformers 4.57.0."""
+"""Lfm2Moe CCE patch. Lfm2Moe inherits Llama. Adapted from transformers 5.12.1."""
 
 # Copyright (C) 2024 Apple Inc. All Rights Reserved.
 
@@ -32,12 +32,12 @@ def patch_lfm2_moe(
     patch_options: PatchOptions,
     remote_model_id: str | None = None,
 ) -> TransformersModelT | None:
-    # Set the _PATCH_OPTS in the mixtral patch file
-    from . import mixtral as mixtral_patch
+    # Set the _PATCH_OPTS in the llama patch file
+    from . import llama as llama_patch
 
-    mixtral_patch._PATCH_OPTS = patch_options
+    llama_patch._PATCH_OPTS = patch_options
 
-    cce_forward = mixtral_patch.cce_forward
+    cce_forward = llama_patch.cce_forward
 
     if remote_model_id is not None:
         patch_remote_model_class(

--- a/cut_cross_entropy/transformers/phi.py
+++ b/cut_cross_entropy/transformers/phi.py
@@ -1,4 +1,4 @@
-"""Phi CCE patch. Phi inherits Llama. Adapted from transformers 5.12.1."""
+"""Phi CCE patch. Adapted from transformers 5.12.1."""
 
 # Copyright (C) 2024 Apple Inc. All Rights Reserved.
 

--- a/cut_cross_entropy/transformers/phi.py
+++ b/cut_cross_entropy/transformers/phi.py
@@ -1,4 +1,4 @@
-"""Phi CCE patch. Phi inherits Llama. Adapted from transformers 4.56.2."""
+"""Phi CCE patch. Phi inherits Llama. Adapted from transformers 5.12.1."""
 
 # Copyright (C) 2024 Apple Inc. All Rights Reserved.
 
@@ -17,14 +17,87 @@
 # limitations under the License.
 
 from types import MethodType
+from typing import Optional, Union
 
+import torch
 import transformers
+from transformers.cache_utils import Cache
+from transformers.modeling_outputs import (
+    BaseModelOutputWithPast,
+    CausalLMOutputWithPast,
+)
 
 from cut_cross_entropy.transformers.utils import (
     PatchOptions,
     TransformersModelT,
+    apply_lce,
     patch_remote_model_class,
 )
+
+_PATCH_OPTS: PatchOptions | None = None
+
+
+def cce_forward(
+    self,
+    input_ids: Optional[torch.LongTensor] = None,
+    attention_mask: Optional[torch.Tensor] = None,
+    position_ids: Optional[torch.LongTensor] = None,
+    past_key_values: Optional[Cache] = None,
+    inputs_embeds: Optional[torch.FloatTensor] = None,
+    labels: Optional[torch.LongTensor] = None,
+    use_cache: Optional[bool] = None,
+    cache_position: Optional[torch.LongTensor] = None,
+    logits_to_keep: Union[int, torch.Tensor] = 0,
+    **kwargs,
+) -> CausalLMOutputWithPast:
+    outputs: BaseModelOutputWithPast = self.model(
+        input_ids=input_ids,
+        attention_mask=attention_mask,
+        position_ids=position_ids,
+        past_key_values=past_key_values,
+        inputs_embeds=inputs_embeds,
+        use_cache=use_cache,
+        cache_position=cache_position,
+        **kwargs,
+    )
+
+    hidden_states = outputs.last_hidden_state
+    loss = None
+    logits = None
+
+    # Only compute necessary logits, and do not upcast them to float if we are not computing the loss
+    slice_indices = (
+        slice(-logits_to_keep, None) if isinstance(logits_to_keep, int) else logits_to_keep
+    )
+    if _PATCH_OPTS is not None and _PATCH_OPTS.use_lce(labels, self.training):
+        assert labels is not None
+        # Phi's lm_head carries a bias; thread it through so the LCE loss matches the full logits.
+        loss = apply_lce(
+            hidden_states[:, slice_indices, :],
+            self.lm_head.weight,
+            labels,
+            _PATCH_OPTS,
+            bias=self.lm_head.bias,
+            **kwargs,
+        )
+    else:
+        logits = self.lm_head(hidden_states[:, slice_indices, :])
+
+        if labels is not None:
+            loss = self.loss_function(
+                logits=logits,
+                labels=labels,
+                vocab_size=self.config.vocab_size,
+                **kwargs,
+            )
+
+    return CausalLMOutputWithPast(
+        loss=loss,
+        logits=logits,
+        past_key_values=outputs.past_key_values,
+        hidden_states=outputs.hidden_states,
+        attentions=outputs.attentions,
+    )
 
 
 def patch_phi(
@@ -32,12 +105,8 @@ def patch_phi(
     patch_options: PatchOptions,
     remote_model_id: str | None = None,
 ) -> TransformersModelT | None:
-    # Set the _PATCH_OPTS in the llama patch file
-    from . import llama as llama_patch
-
-    llama_patch._PATCH_OPTS = patch_options
-
-    cce_forward = llama_patch.cce_forward
+    global _PATCH_OPTS
+    _PATCH_OPTS = patch_options
 
     if remote_model_id is not None:
         patch_remote_model_class(

--- a/cut_cross_entropy/transformers/qwen2_moe.py
+++ b/cut_cross_entropy/transformers/qwen2_moe.py
@@ -1,4 +1,4 @@
-"""Qwen2 MoE CCE patch. Adapted from transformers v4.56.2."""
+"""Qwen2 MoE CCE patch. Adapted from transformers 5.12.1."""
 
 # Copyright (C) 2024 Apple Inc. All Rights Reserved.
 
@@ -47,25 +47,14 @@ def cce_forward(
     inputs_embeds: Optional[torch.FloatTensor] = None,
     labels: Optional[torch.LongTensor] = None,
     use_cache: Optional[bool] = None,
-    output_attentions: Optional[bool] = None,
-    output_hidden_states: Optional[bool] = None,
     output_router_logits: Optional[bool] = None,
-    cache_position: Optional[torch.LongTensor] = None,
     logits_to_keep: Union[int, torch.Tensor] = 0,
-    **loss_kwargs,
+    **kwargs,
 ) -> MoeCausalLMOutputWithPast:
-    output_attentions = (
-        output_attentions if output_attentions is not None else self.config.output_attentions
-    )
     output_router_logits = (
         output_router_logits
         if output_router_logits is not None
         else self.config.output_router_logits
-    )
-    output_hidden_states = (
-        output_hidden_states
-        if output_hidden_states is not None
-        else self.config.output_hidden_states
     )
 
     # decoder outputs consists of (dec_features, layer_state, dec_hidden, dec_attn)
@@ -76,10 +65,8 @@ def cce_forward(
         past_key_values=past_key_values,
         inputs_embeds=inputs_embeds,
         use_cache=use_cache,
-        output_attentions=output_attentions,
-        output_hidden_states=output_hidden_states,
         output_router_logits=output_router_logits,
-        cache_position=cache_position,
+        **kwargs,
     )
 
     hidden_states = outputs.last_hidden_state
@@ -98,13 +85,13 @@ def cce_forward(
             self.lm_head.weight,
             labels,
             _PATCH_OPTS,
-            **loss_kwargs,
+            **kwargs,
         )
     else:
         logits = self.lm_head(hidden_states[:, slice_indices, :])
 
         if labels is not None:
-            loss = self.loss_function(logits, labels, self.vocab_size, **loss_kwargs)
+            loss = self.loss_function(logits, labels, self.vocab_size, **kwargs)
 
     aux_loss = None
     if output_router_logits:

--- a/cut_cross_entropy/transformers/qwen2_vl.py
+++ b/cut_cross_entropy/transformers/qwen2_vl.py
@@ -1,4 +1,4 @@
-"""Qwen2 VL CCE patch. Adapted from transformers v4.56.2."""
+"""Qwen2 VL CCE patch. Adapted from transformers 5.12.1."""
 
 # Copyright (C) 2024 Apple Inc. All Rights Reserved.
 
@@ -97,7 +97,10 @@ def cce_forward_multimodal(
 
         if labels is not None:
             loss = self.loss_function(
-                logits=logits, labels=labels, vocab_size=self.config.vocab_size, **kwargs
+                logits=logits,
+                labels=labels,
+                vocab_size=self.config.text_config.vocab_size,
+                **kwargs,
             )
 
     return Qwen2VLCausalLMOutputWithPast(

--- a/cut_cross_entropy/transformers/qwen3_5.py
+++ b/cut_cross_entropy/transformers/qwen3_5.py
@@ -1,4 +1,4 @@
-"""Qwen3_5 CCE patch. CausalLM inherits Qwen3 (Llama), ConditionalGeneration inherits Qwen3VL."""
+"""Qwen3_5 CCE patch. CausalLM inherits Qwen3 (Llama), ConditionalGeneration inherits Qwen3VL. Adapted from transformers 5.12.1."""
 
 # Copyright (C) 2024 Apple Inc. All Rights Reserved.
 

--- a/cut_cross_entropy/transformers/qwen3_5_moe.py
+++ b/cut_cross_entropy/transformers/qwen3_5_moe.py
@@ -1,4 +1,4 @@
-"""Qwen3_5 MoE CCE patch. CausalLM inherits Qwen3Next (Mixtral), ConditionalGeneration inherits Qwen3VLMoe."""
+"""Qwen3_5 MoE CCE patch. Adapted from transformers 5.12.1."""
 
 # Copyright (C) 2024 Apple Inc. All Rights Reserved.
 
@@ -66,13 +66,13 @@ def patch_qwen3_5_moe(
     from . import qwen3_vl as qwen3_vl_patch
 
     qwen3_vl_patch._PATCH_OPTS = patch_options
-    cce_forward_multimodal = qwen3_vl_patch.cce_forward_multimodal
+    cce_forward_multimodal_moe = qwen3_vl_patch.cce_forward_multimodal_moe
 
     if remote_model_id is not None:
         patch_remote_model_class(
             remote_model_id=remote_model_id,
             class_name="Qwen3_5MoeForConditionalGeneration",
-            patch_fn=cce_forward_multimodal,
+            patch_fn=cce_forward_multimodal_moe,
         )
         return None
 
@@ -82,8 +82,8 @@ def patch_qwen3_5_moe(
         assert isinstance(maybe_model, modeling_qwen3_5_moe.Qwen3_5MoeForConditionalGeneration), (
             f"Expected a Qwen3_5MoeForConditionalGeneration model. Got {type(maybe_model)}."
         )
-        maybe_model.forward = MethodType(cce_forward_multimodal, maybe_model)
+        maybe_model.forward = MethodType(cce_forward_multimodal_moe, maybe_model)
         return maybe_model
 
-    modeling_qwen3_5_moe.Qwen3_5MoeForConditionalGeneration.forward = cce_forward_multimodal
+    modeling_qwen3_5_moe.Qwen3_5MoeForConditionalGeneration.forward = cce_forward_multimodal_moe
     return None

--- a/cut_cross_entropy/transformers/seed_oss.py
+++ b/cut_cross_entropy/transformers/seed_oss.py
@@ -1,4 +1,4 @@
-"""Seed_OSS CCE patch. Inherits Llama. Adapted from transformers v4.56.2."""
+"""Seed_OSS CCE patch. Inherits Llama. Adapted from transformers 5.12.1."""
 
 # Copyright (C) 2024 Apple Inc. All Rights Reserved.
 
@@ -47,14 +47,14 @@ def patch_seed_oss(
         )
         return None
 
-    from transformers.models.seed_oss import modular_seed_oss
+    from transformers.models.seed_oss import modeling_seed_oss
 
     if isinstance(maybe_model, transformers.PreTrainedModel):
-        assert isinstance(maybe_model, modular_seed_oss.SeedOssForCausalLM), (
+        assert isinstance(maybe_model, modeling_seed_oss.SeedOssForCausalLM), (
             f"Expected a SeedOssForCausalLM model. Got {type(maybe_model)}."
         )
         maybe_model.forward = MethodType(cce_forward, maybe_model)
         return maybe_model
 
-    modular_seed_oss.SeedOssForCausalLM.forward = cce_forward
+    modeling_seed_oss.SeedOssForCausalLM.forward = cce_forward
     return None

--- a/cut_cross_entropy/transformers/voxtral.py
+++ b/cut_cross_entropy/transformers/voxtral.py
@@ -1,4 +1,4 @@
-"""Voxtral CCE patch. Voxtral uses Llama. Adapted from transformers v4.56.2."""
+"""Voxtral CCE patch. Adapted from transformers 5.12.1."""
 
 # Copyright (C) 2024 Apple Inc. All Rights Reserved.
 
@@ -17,14 +17,82 @@
 # limitations under the License.
 
 from types import MethodType
+from typing import Optional, Union
 
+import torch
 import transformers
+from transformers.cache_utils import Cache
+from transformers.modeling_outputs import CausalLMOutputWithPast
 
 from cut_cross_entropy.transformers.utils import (
     PatchOptions,
     TransformersModelT,
+    apply_lce,
     patch_remote_model_class,
 )
+
+_PATCH_OPTS: PatchOptions | None = None
+
+
+def cce_forward(
+    self,
+    input_ids: Optional[torch.LongTensor] = None,
+    input_features: Optional[torch.FloatTensor] = None,
+    attention_mask: Optional[torch.Tensor] = None,
+    position_ids: Optional[torch.LongTensor] = None,
+    past_key_values: Optional[Cache] = None,
+    inputs_embeds: Optional[torch.FloatTensor] = None,
+    labels: Optional[torch.LongTensor] = None,
+    use_cache: Optional[bool] = None,
+    logits_to_keep: Union[int, torch.Tensor] = 0,
+    **kwargs,
+) -> Union[tuple, CausalLMOutputWithPast]:
+    outputs = self.model(
+        input_ids=input_ids,
+        input_features=input_features,
+        attention_mask=attention_mask,
+        position_ids=position_ids,
+        past_key_values=past_key_values,
+        inputs_embeds=inputs_embeds,
+        use_cache=use_cache,
+        **kwargs,
+    )
+
+    hidden_states = outputs.last_hidden_state
+    loss = None
+    logits = None
+
+    slice_indices = (
+        slice(-logits_to_keep, None) if isinstance(logits_to_keep, int) else logits_to_keep
+    )
+
+    if _PATCH_OPTS is not None and _PATCH_OPTS.use_lce(labels, self.training):
+        assert labels is not None
+        loss = apply_lce(
+            hidden_states[:, slice_indices, :],
+            self.lm_head.weight,
+            labels,
+            _PATCH_OPTS,
+            **kwargs,
+        )
+    else:
+        logits = self.lm_head(hidden_states[:, slice_indices, :])
+
+        if labels is not None:
+            loss = self.loss_function(
+                logits=logits,
+                labels=labels,
+                vocab_size=self.config.text_config.vocab_size,
+                **kwargs,
+            )
+
+    return CausalLMOutputWithPast(
+        loss=loss,
+        logits=logits,
+        past_key_values=outputs.past_key_values,
+        hidden_states=outputs.hidden_states,
+        attentions=outputs.attentions,
+    )
 
 
 def patch_voxtral(
@@ -32,29 +100,25 @@ def patch_voxtral(
     patch_options: PatchOptions,
     remote_model_id: str | None = None,
 ) -> TransformersModelT | None:
-    # Set the _PATCH_OPTS in the llama patch file
-    from . import llama as llama_patch
-
-    llama_patch._PATCH_OPTS = patch_options
-
-    cce_forward = llama_patch.cce_forward
+    global _PATCH_OPTS
+    _PATCH_OPTS = patch_options
 
     if remote_model_id is not None:
         patch_remote_model_class(
             remote_model_id=remote_model_id,
-            class_name="LlamaForCausalLM",
+            class_name="VoxtralForConditionalGeneration",
             patch_fn=cce_forward,
         )
         return None
 
-    from transformers.models.llama import modeling_llama
+    from transformers.models.voxtral import modeling_voxtral
 
     if isinstance(maybe_model, transformers.PreTrainedModel):
-        assert isinstance(maybe_model, modeling_llama.LlamaForCausalLM), (
-            f"Expected a LlamaForCausalLM model. Got {type(maybe_model)}."
+        assert isinstance(maybe_model, modeling_voxtral.VoxtralForConditionalGeneration), (
+            f"Expected a VoxtralForConditionalGeneration model. Got {type(maybe_model)}."
         )
         maybe_model.forward = MethodType(cce_forward, maybe_model)
         return maybe_model
 
-    modeling_llama.LlamaForCausalLM.forward = cce_forward
+    modeling_voxtral.VoxtralForConditionalGeneration.forward = cce_forward
     return None


### PR DESCRIPTION
There were a lot of stale patches given the inheritance path changed during the transformers v4->v5 migration. This PR fixes that