### PR TITLE
fix: update leftover stale patches for transformers 5.12

### DIFF
--- a/cut_cross_entropy/transformers/cohere.py
+++ b/cut_cross_entropy/transformers/cohere.py
@@ -46,22 +46,9 @@ def cce_forward(
     inputs_embeds: Optional[torch.FloatTensor] = None,
     labels: Optional[torch.LongTensor] = None,
     use_cache: Optional[bool] = None,
-    output_attentions: Optional[bool] = None,
-    output_hidden_states: Optional[bool] = None,
-    cache_position: Optional[torch.LongTensor] = None,
     logits_to_keep: Union[int, torch.Tensor] = 0,
     **kwargs,
 ) -> CausalLMOutputWithPast:
-    output_attentions = (
-        output_attentions if output_attentions is not None else self.config.output_attentions
-    )
-    output_hidden_states = (
-        output_hidden_states
-        if output_hidden_states is not None
-        else self.config.output_hidden_states
-    )
-
-    # decoder outputs consists of (dec_features, layer_state, dec_hidden, dec_attn)
     outputs: BaseModelOutputWithPast = self.model(
         input_ids=input_ids,
         attention_mask=attention_mask,
@@ -69,9 +56,6 @@ def cce_forward(
         past_key_values=past_key_values,
         inputs_embeds=inputs_embeds,
         use_cache=use_cache,
-        output_attentions=output_attentions,
-        output_hidden_states=output_hidden_states,
-        cache_position=cache_position,
         **kwargs,
     )
 

--- a/cut_cross_entropy/transformers/exaone4_5.py
+++ b/cut_cross_entropy/transformers/exaone4_5.py
@@ -1,4 +1,4 @@
-"""Exaone4_5 (VLM) CCE patch. Adapted from transformers 5.10.1."""
+"""Exaone4_5 (VLM) CCE patch. Adapted from transformers 5.12.1."""
 
 # Copyright (C) 2024 Apple Inc. All Rights Reserved.
 
@@ -47,7 +47,6 @@ def cce_forward_multimodal(
     pixel_values_videos: Optional[torch.FloatTensor] = None,
     image_grid_thw: Optional[torch.LongTensor] = None,
     video_grid_thw: Optional[torch.LongTensor] = None,
-    second_per_grid_ts: Optional[torch.Tensor] = None,
     logits_to_keep: Union[int, torch.Tensor] = 0,
     **kwargs,
 ) -> Union[Tuple, CausalLMOutputWithPast]:
@@ -57,7 +56,6 @@ def cce_forward_multimodal(
         pixel_values_videos=pixel_values_videos,
         image_grid_thw=image_grid_thw,
         video_grid_thw=video_grid_thw,
-        second_per_grid_ts=second_per_grid_ts,
         position_ids=position_ids,
         attention_mask=attention_mask,
         past_key_values=past_key_values,

--- a/cut_cross_entropy/transformers/gemma3.py
+++ b/cut_cross_entropy/transformers/gemma3.py
@@ -51,20 +51,9 @@ def cce_forward(
     inputs_embeds: Optional[torch.FloatTensor] = None,
     labels: Optional[torch.LongTensor] = None,
     use_cache: Optional[bool] = None,
-    output_attentions: Optional[bool] = None,
-    output_hidden_states: Optional[bool] = None,
-    cache_position: Optional[torch.LongTensor] = None,
     logits_to_keep: Union[int, torch.Tensor] = 0,
     **loss_kwargs,
 ) -> CausalLMOutputWithPast:
-    output_attentions = (
-        output_attentions if output_attentions is not None else self.config.output_attentions
-    )
-    output_hidden_states = (
-        output_hidden_states
-        if output_hidden_states is not None
-        else self.config.output_hidden_states
-    )
     # decoder outputs consists of (dec_features, layer_state, dec_hidden, dec_attn)
     outputs: BaseModelOutputWithPast = self.model(
         input_ids=input_ids,
@@ -73,9 +62,6 @@ def cce_forward(
         past_key_values=past_key_values,
         inputs_embeds=inputs_embeds,
         use_cache=use_cache,
-        output_attentions=output_attentions,
-        output_hidden_states=output_hidden_states,
-        cache_position=cache_position,
         **loss_kwargs,
     )
 
@@ -125,25 +111,14 @@ def cce_forward_multimodal(
     position_ids: Optional[torch.LongTensor] = None,
     past_key_values: Optional[Union[list[torch.FloatTensor], Cache]] = None,
     token_type_ids: Optional[torch.LongTensor] = None,
-    cache_position: Optional[torch.LongTensor] = None,
     inputs_embeds: Optional[torch.FloatTensor] = None,
     labels: Optional[torch.LongTensor] = None,
     use_cache: Optional[bool] = None,
-    output_attentions: Optional[bool] = None,
-    output_hidden_states: Optional[bool] = None,
-    return_dict: Optional[bool] = None,
     logits_to_keep: Union[int, torch.Tensor] = 0,
     **lm_kwargs,
 ) -> Union[Tuple, Gemma3CausalLMOutputWithPast]:
-    output_attentions = (
-        output_attentions if output_attentions is not None else self.config.output_attentions
-    )
-    output_hidden_states = (
-        output_hidden_states
-        if output_hidden_states is not None
-        else self.config.output_hidden_states
-    )
-    return_dict = return_dict if return_dict is not None else self.config.use_return_dict
+    # Strip PEFT-injected return_dict so it doesn't collide with the explicit return_dict=True below.
+    lm_kwargs.pop("return_dict", None)
 
     outputs: Gemma3ModelOutputWithPast = self.model(
         input_ids=input_ids,
@@ -155,10 +130,7 @@ def cce_forward_multimodal(
         inputs_embeds=inputs_embeds,
         use_cache=use_cache,
         labels=labels,
-        output_attentions=output_attentions,
-        output_hidden_states=output_hidden_states,
-        return_dict=return_dict,
-        cache_position=cache_position,
+        return_dict=True,
         **lm_kwargs,
     )
 
@@ -208,10 +180,6 @@ def cce_forward_multimodal(
             flat_logits = shift_logits.view(-1, self.config.text_config.vocab_size)
             flat_labels = shift_labels.view(-1).to(shift_logits.device)
             loss = loss_fct(flat_logits, flat_labels)
-
-    if not return_dict:
-        output = (logits,) + outputs[1:]
-        return (loss,) + output if loss is not None else output
 
     return Gemma3CausalLMOutputWithPast(
         loss=loss,

--- a/cut_cross_entropy/transformers/gemma3n.py
+++ b/cut_cross_entropy/transformers/gemma3n.py
@@ -46,20 +46,9 @@ def cce_forward(
     inputs_embeds: Optional[torch.FloatTensor] = None,
     labels: Optional[torch.LongTensor] = None,
     use_cache: Optional[bool] = None,
-    output_attentions: Optional[bool] = None,
-    output_hidden_states: Optional[bool] = None,
-    cache_position: Optional[torch.LongTensor] = None,
     logits_to_keep: Union[int, torch.Tensor] = 0,
     **loss_kwargs,
 ) -> CausalLMOutputWithPast:
-    output_attentions = (
-        output_attentions if output_attentions is not None else self.config.output_attentions
-    )
-    output_hidden_states = (
-        output_hidden_states
-        if output_hidden_states is not None
-        else self.config.output_hidden_states
-    )
     # decoder outputs consists of (dec_features, layer_state, dec_hidden, dec_attn)
     outputs = self.model(
         input_ids=input_ids,
@@ -68,9 +57,6 @@ def cce_forward(
         past_key_values=past_key_values,
         inputs_embeds=inputs_embeds,
         use_cache=use_cache,
-        output_attentions=output_attentions,
-        output_hidden_states=output_hidden_states,
-        cache_position=cache_position,
         **loss_kwargs,
     )
 
@@ -122,24 +108,12 @@ def cce_forward_multimodal(
     position_ids: Optional[torch.LongTensor] = None,
     past_key_values: Optional[Union[list[torch.FloatTensor], Cache]] = None,
     token_type_ids: Optional[torch.LongTensor] = None,
-    cache_position: Optional[torch.LongTensor] = None,
     inputs_embeds: Optional[torch.FloatTensor] = None,
     labels: Optional[torch.LongTensor] = None,
     use_cache: Optional[bool] = None,
-    output_attentions: Optional[bool] = None,
-    output_hidden_states: Optional[bool] = None,
     logits_to_keep: Union[int, torch.Tensor] = 0,
     **lm_kwargs,
 ) -> Gemma3nCausalLMOutputWithPast:
-    output_attentions = (
-        output_attentions if output_attentions is not None else self.config.output_attentions
-    )
-    output_hidden_states = (
-        output_hidden_states
-        if output_hidden_states is not None
-        else self.config.output_hidden_states
-    )
-
     # Strip PEFT-injected return_dict so it doesn't collide with the explicit return_dict=True below.
     lm_kwargs.pop("return_dict", None)
 
@@ -152,12 +126,9 @@ def cce_forward_multimodal(
         position_ids=position_ids,
         past_key_values=past_key_values,
         token_type_ids=token_type_ids,
-        cache_position=cache_position,
         inputs_embeds=inputs_embeds,
         labels=labels,
         use_cache=use_cache,
-        output_attentions=output_attentions,
-        output_hidden_states=output_hidden_states,
         return_dict=True,
         **lm_kwargs,
     )

--- a/cut_cross_entropy/transformers/glm_image.py
+++ b/cut_cross_entropy/transformers/glm_image.py
@@ -46,7 +46,7 @@ def cce_forward_multimodal(
     labels: torch.LongTensor | None = None,
     pixel_values: torch.Tensor | None = None,
     image_grid_thw: torch.LongTensor | None = None,
-    cache_position: torch.LongTensor | None = None,
+    images_per_sample: torch.LongTensor | None = None,
     logits_to_keep: int | torch.Tensor = 0,
     **kwargs,
 ) -> Union[tuple, GlmImageCausalLMOutputWithPast]:
@@ -54,11 +54,11 @@ def cce_forward_multimodal(
         input_ids=input_ids,
         pixel_values=pixel_values,
         image_grid_thw=image_grid_thw,
+        images_per_sample=images_per_sample,
         position_ids=position_ids,
         attention_mask=attention_mask,
         past_key_values=past_key_values,
         inputs_embeds=inputs_embeds,
-        cache_position=cache_position,
         **kwargs,
     )
 

--- a/cut_cross_entropy/transformers/granite.py
+++ b/cut_cross_entropy/transformers/granite.py
@@ -46,22 +46,9 @@ def cce_forward(
     inputs_embeds: Optional[torch.FloatTensor] = None,
     labels: Optional[torch.LongTensor] = None,
     use_cache: Optional[bool] = None,
-    output_attentions: Optional[bool] = None,
-    output_hidden_states: Optional[bool] = None,
-    cache_position: Optional[torch.LongTensor] = None,
     logits_to_keep: Union[int, torch.Tensor] = 0,
     **kwargs,
 ) -> CausalLMOutputWithPast:
-    output_attentions = (
-        output_attentions if output_attentions is not None else self.config.output_attentions
-    )
-    output_hidden_states = (
-        output_hidden_states
-        if output_hidden_states is not None
-        else self.config.output_hidden_states
-    )
-
-    # decoder outputs consists of (dec_features, layer_state, dec_hidden, dec_attn)
     outputs: BaseModelOutputWithPast = self.model(
         input_ids=input_ids,
         attention_mask=attention_mask,
@@ -69,9 +56,6 @@ def cce_forward(
         past_key_values=past_key_values,
         inputs_embeds=inputs_embeds,
         use_cache=use_cache,
-        output_attentions=output_attentions,
-        output_hidden_states=output_hidden_states,
-        cache_position=cache_position,
         **kwargs,
     )
 

--- a/cut_cross_entropy/transformers/granitemoe.py
+++ b/cut_cross_entropy/transformers/granitemoe.py
@@ -45,30 +45,15 @@ def cce_forward(
     past_key_values: Optional[Union[Cache, list[torch.FloatTensor]]] = None,
     inputs_embeds: Optional[torch.FloatTensor] = None,
     labels: Optional[torch.LongTensor] = None,
-    use_cache: Optional[bool] = None,
-    output_attentions: Optional[bool] = None,
-    output_hidden_states: Optional[bool] = None,
     output_router_logits: Optional[bool] = None,
-    return_dict: Optional[bool] = None,
-    cache_position: Optional[torch.LongTensor] = None,
     logits_to_keep: Union[int, torch.Tensor] = 0,
     **kwargs,
 ) -> MoeCausalLMOutputWithPast:
-    output_attentions = (
-        output_attentions if output_attentions is not None else self.config.output_attentions
-    )
     output_router_logits = (
         output_router_logits
         if output_router_logits is not None
         else self.config.output_router_logits
     )
-    output_hidden_states = (
-        output_hidden_states
-        if output_hidden_states is not None
-        else self.config.output_hidden_states
-    )
-    return_dict = return_dict if return_dict is not None else self.config.use_return_dict
-
     # decoder outputs consists of (dec_features, layer_state, dec_hidden, dec_attn)
     outputs = self.model(
         input_ids=input_ids,
@@ -76,17 +61,11 @@ def cce_forward(
         position_ids=position_ids,
         past_key_values=past_key_values,
         inputs_embeds=inputs_embeds,
-        use_cache=use_cache,
-        output_attentions=output_attentions,
-        output_hidden_states=output_hidden_states,
-        output_router_logits=output_router_logits,
-        return_dict=return_dict,
-        cache_position=cache_position,
         **kwargs,
     )
 
     # Only compute necessary logits
-    hidden_states = outputs[0]
+    hidden_states = outputs.last_hidden_state
     loss = None
     logits = None
     slice_indices = (
@@ -121,7 +100,7 @@ def cce_forward(
     aux_loss = None
     if output_router_logits:
         aux_loss = load_balancing_loss_func(
-            outputs.router_logits if return_dict else outputs[-1],
+            outputs.router_logits,
             self.num_experts,
             self.num_experts_per_tok,
             attention_mask,
@@ -130,12 +109,6 @@ def cce_forward(
             loss += self.router_aux_loss_coef * aux_loss.to(
                 loss.device
             )  # make sure to reside in the same device
-
-    if not return_dict:
-        output = (logits,) + outputs[1:]
-        if output_router_logits:
-            output = (aux_loss,) + output
-        return (loss,) + output if loss is not None else output
 
     return MoeCausalLMOutputWithPast(
         loss=loss,

--- a/cut_cross_entropy/transformers/lfm2_vl.py
+++ b/cut_cross_entropy/transformers/lfm2_vl.py
@@ -46,7 +46,6 @@ def cce_forward_multimodal(
     inputs_embeds: Optional[torch.FloatTensor] = None,
     labels: Optional[torch.LongTensor] = None,
     use_cache: Optional[bool] = None,
-    cache_position: Optional[torch.LongTensor] = None,
     logits_to_keep: Union[int, torch.Tensor] = 0,
     **kwargs,
 ):
@@ -60,7 +59,6 @@ def cce_forward_multimodal(
         past_key_values=past_key_values,
         inputs_embeds=inputs_embeds,
         use_cache=use_cache,
-        cache_position=cache_position,
         **kwargs,
     )
 

--- a/cut_cross_entropy/transformers/llama.py
+++ b/cut_cross_entropy/transformers/llama.py
@@ -46,7 +46,6 @@ def cce_forward(
     inputs_embeds: Optional[torch.FloatTensor] = None,
     labels: Optional[torch.LongTensor] = None,
     use_cache: Optional[bool] = None,
-    cache_position: Optional[torch.LongTensor] = None,
     logits_to_keep: Union[int, torch.Tensor] = 0,
     **kwargs,
 ) -> CausalLMOutputWithPast:
@@ -57,7 +56,6 @@ def cce_forward(
         past_key_values=past_key_values,
         inputs_embeds=inputs_embeds,
         use_cache=use_cache,
-        cache_position=cache_position,
         **kwargs,
     )
 

--- a/cut_cross_entropy/transformers/llama4.py
+++ b/cut_cross_entropy/transformers/llama4.py
@@ -1,4 +1,4 @@
-"""Llama4 CCE patch. Adapted from transformers 4.56.2."""
+"""Llama4 CCE patch. Adapted from transformers 5.12.1."""
 
 # Copyright (C) 2024 Apple Inc. All Rights Reserved.
 
@@ -15,9 +15,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-# This patch still uses the old VLM API as transformers
-# did not update Llama4 to the new API yet.
 
 from types import MethodType
 from typing import Optional, Tuple, Union
@@ -46,11 +43,10 @@ def cce_forward(
     input_ids: Optional[torch.LongTensor] = None,
     attention_mask: Optional[torch.Tensor] = None,
     position_ids: Optional[torch.LongTensor] = None,
-    past_key_values: Optional[Union[Cache, list[torch.FloatTensor]]] = None,
+    past_key_values: Optional[Cache] = None,
     inputs_embeds: Optional[torch.FloatTensor] = None,
     labels: Optional[torch.LongTensor] = None,
     use_cache: Optional[bool] = None,
-    cache_position: Optional[torch.LongTensor] = None,
     logits_to_keep: Union[int, torch.Tensor] = 0,
     defer_logits_calculation: bool = False,
     **kwargs,
@@ -62,7 +58,6 @@ def cce_forward(
         past_key_values=past_key_values,
         inputs_embeds=inputs_embeds,
         use_cache=use_cache,
-        cache_position=cache_position,
         **kwargs,
     )
 
@@ -114,17 +109,18 @@ def cce_forward_multimodal(
     position_ids: Optional[torch.LongTensor] = None,
     past_key_values: Optional[Cache] = None,
     inputs_embeds: Optional[torch.FloatTensor] = None,
-    vision_feature_layer: Optional[Union[int, list[int]]] = None,
     vision_feature_select_strategy: Optional[str] = None,
     labels: Optional[torch.LongTensor] = None,
     use_cache: Optional[bool] = None,
     output_attentions: Optional[bool] = None,
     output_hidden_states: Optional[bool] = None,
     return_dict: Optional[bool] = None,
-    cache_position: Optional[torch.LongTensor] = None,
     logits_to_keep: Union[int, torch.Tensor] = 0,
     **kwargs,
 ) -> Union[Tuple, Llama4CausalLMOutputWithPast]:
+    # Strip PEFT-injected return_dict so it doesn't collide with the explicit return_dict=True below.
+    kwargs.pop("return_dict", None)
+
     output_attentions = (
         output_attentions if output_attentions is not None else self.config.output_attentions
     )
@@ -133,7 +129,7 @@ def cce_forward_multimodal(
         if output_hidden_states is not None
         else self.config.output_hidden_states
     )
-    return_dict = return_dict if return_dict is not None else self.config.use_return_dict
+    return_dict = return_dict if return_dict is not None else self.config.return_dict
     vision_feature_select_strategy = (
         vision_feature_select_strategy
         if vision_feature_select_strategy is not None
@@ -155,7 +151,8 @@ def cce_forward_multimodal(
         image_features = self.get_image_features(
             pixel_values=pixel_values,
             vision_feature_select_strategy=vision_feature_select_strategy,
-        )
+            return_dict=True,
+        ).last_hidden_state
 
         vision_flat = image_features.view(-1, image_features.size(-1))
         projected_vision_flat = self.multi_modal_projector(vision_flat).to(
@@ -175,7 +172,6 @@ def cce_forward_multimodal(
         output_attentions=output_attentions,
         output_hidden_states=output_hidden_states,
         return_dict=return_dict,
-        cache_position=cache_position,
         logits_to_keep=logits_to_keep,
         defer_logits_calculation=True,  # enable deferred logits calculation
         **kwargs,
@@ -196,7 +192,9 @@ def cce_forward_multimodal(
             **kwargs,
         )
     else:
-        logits = hidden_states
+        # The language model deferred its logits projection (defer_logits_calculation=True),
+        # so hidden_states is the raw hidden state; project it to logits like upstream does.
+        logits = self.language_model.lm_head(hidden_states)
         if labels is not None:
             # Shift so that tokens < n predict n
             if attention_mask is not None:

--- a/cut_cross_entropy/transformers/llava.py
+++ b/cut_cross_entropy/transformers/llava.py
@@ -45,7 +45,6 @@ def cce_forward(
     vision_feature_layer: Optional[Union[int, list[int]]] = None,
     vision_feature_select_strategy: Optional[str] = None,
     labels: Optional[torch.LongTensor] = None,
-    cache_position: Optional[torch.LongTensor] = None,
     logits_to_keep: Union[int, torch.Tensor] = 0,
     image_sizes: Optional[torch.Tensor] = None,
     **kwargs,
@@ -70,7 +69,6 @@ def cce_forward(
         inputs_embeds=inputs_embeds,
         vision_feature_layer=vision_feature_layer,
         vision_feature_select_strategy=vision_feature_select_strategy,
-        cache_position=cache_position,
         image_sizes=image_sizes,
         **kwargs,
     )

--- a/cut_cross_entropy/transformers/mistral3.py
+++ b/cut_cross_entropy/transformers/mistral3.py
@@ -46,24 +46,10 @@ def cce_forward_multimodal(
     inputs_embeds: Optional[torch.FloatTensor] = None,
     labels: Optional[torch.LongTensor] = None,
     use_cache: Optional[bool] = None,
-    output_attentions: Optional[bool] = None,
-    output_hidden_states: Optional[bool] = None,
-    return_dict: Optional[bool] = None,
-    cache_position: Optional[torch.LongTensor] = None,
     logits_to_keep: Union[int, torch.Tensor] = 0,
     image_sizes: Optional[torch.Tensor] = None,
     **kwargs,
 ) -> Union[Tuple, Mistral3CausalLMOutputWithPast]:
-    output_attentions = (
-        output_attentions if output_attentions is not None else self.config.output_attentions
-    )
-    output_hidden_states = (
-        output_hidden_states
-        if output_hidden_states is not None
-        else self.config.output_hidden_states
-    )
-    return_dict = return_dict if return_dict is not None else self.config.use_return_dict
-
     outputs = self.model(
         input_ids=input_ids,
         pixel_values=pixel_values,
@@ -72,10 +58,6 @@ def cce_forward_multimodal(
         past_key_values=past_key_values,
         inputs_embeds=inputs_embeds,
         use_cache=use_cache,
-        output_attentions=output_attentions,
-        output_hidden_states=output_hidden_states,
-        return_dict=True,
-        cache_position=cache_position,
         image_sizes=image_sizes,
         **kwargs,
     )
@@ -107,10 +89,6 @@ def cce_forward_multimodal(
                 vocab_size=self.config.text_config.vocab_size,
                 **kwargs,
             )
-
-    if not return_dict:
-        output = (logits,) + outputs[1:]
-        return (loss,) + output if loss is not None else output
 
     return Mistral3CausalLMOutputWithPast(
         loss=loss,

--- a/cut_cross_entropy/transformers/mixtral.py
+++ b/cut_cross_entropy/transformers/mixtral.py
@@ -48,7 +48,6 @@ def cce_forward(
     labels: Optional[torch.LongTensor] = None,
     use_cache: Optional[bool] = None,
     output_router_logits: Optional[bool] = None,
-    cache_position: Optional[torch.LongTensor] = None,
     logits_to_keep: Union[int, torch.Tensor] = 0,
     **kwargs,
 ) -> MoeCausalLMOutputWithPast:
@@ -67,7 +66,6 @@ def cce_forward(
         inputs_embeds=inputs_embeds,
         use_cache=use_cache,
         output_router_logits=output_router_logits,
-        cache_position=cache_position,
         **kwargs,
     )
 

--- a/cut_cross_entropy/transformers/mllama.py
+++ b/cut_cross_entropy/transformers/mllama.py
@@ -49,7 +49,6 @@ def cce_forward(
     inputs_embeds: Optional[torch.FloatTensor] = None,
     labels: Optional[torch.LongTensor] = None,
     use_cache: Optional[bool] = None,
-    cache_position: Optional[torch.LongTensor] = None,
     logits_to_keep: Union[int, torch.Tensor] = 0,
     **kwargs,
 ) -> Union[Tuple, CausalLMOutputWithPast]:
@@ -64,7 +63,6 @@ def cce_forward(
         past_key_values=past_key_values,
         inputs_embeds=inputs_embeds,
         use_cache=use_cache,
-        cache_position=cache_position,
         **kwargs,
     )
 
@@ -114,23 +112,9 @@ def cce_forward_multimodal(
     inputs_embeds: Optional[torch.FloatTensor] = None,
     labels: Optional[torch.LongTensor] = None,
     use_cache: Optional[bool] = None,
-    output_attentions: Optional[bool] = None,
-    output_hidden_states: Optional[bool] = None,
-    return_dict: Optional[bool] = None,
-    cache_position: Optional[torch.LongTensor] = None,
     logits_to_keep: Union[int, torch.Tensor] = 0,
     **kwargs,
 ) -> Union[Tuple, CausalLMOutputWithPast]:
-    output_attentions = (
-        output_attentions if output_attentions is not None else self.config.output_attentions
-    )
-    output_hidden_states = (
-        output_hidden_states
-        if output_hidden_states is not None
-        else self.config.output_hidden_states
-    )
-    return_dict = return_dict if return_dict is not None else self.config.use_return_dict
-
     outputs: BaseModelOutputWithPast = self.model(
         input_ids=input_ids,
         pixel_values=pixel_values,
@@ -143,10 +127,6 @@ def cce_forward_multimodal(
         past_key_values=past_key_values,
         inputs_embeds=inputs_embeds,
         use_cache=use_cache,
-        output_attentions=output_attentions,
-        output_hidden_states=output_hidden_states,
-        return_dict=True,
-        cache_position=cache_position,
         **kwargs,
     )
 

--- a/cut_cross_entropy/transformers/phi.py
+++ b/cut_cross_entropy/transformers/phi.py
@@ -46,7 +46,6 @@ def cce_forward(
     inputs_embeds: Optional[torch.FloatTensor] = None,
     labels: Optional[torch.LongTensor] = None,
     use_cache: Optional[bool] = None,
-    cache_position: Optional[torch.LongTensor] = None,
     logits_to_keep: Union[int, torch.Tensor] = 0,
     **kwargs,
 ) -> CausalLMOutputWithPast:
@@ -57,7 +56,6 @@ def cce_forward(
         past_key_values=past_key_values,
         inputs_embeds=inputs_embeds,
         use_cache=use_cache,
-        cache_position=cache_position,
         **kwargs,
     )
 

--- a/cut_cross_entropy/transformers/phi4_multimodal.py
+++ b/cut_cross_entropy/transformers/phi4_multimodal.py
@@ -49,21 +49,9 @@ def cce_forward_multimodal(
     audio_attention_mask=None,
     labels: Optional[torch.LongTensor] = None,
     use_cache: Optional[bool] = None,
-    output_attentions: Optional[bool] = None,
-    output_hidden_states: Optional[bool] = None,
-    cache_position: Optional[torch.LongTensor] = None,
     logits_to_keep: Union[int, torch.Tensor] = 0,
     **kwargs,
 ) -> CausalLMOutputWithPast:
-    output_attentions = (
-        output_attentions if output_attentions is not None else self.config.output_attentions
-    )
-    output_hidden_states = (
-        output_hidden_states
-        if output_hidden_states is not None
-        else self.config.output_hidden_states
-    )
-
     # decoder outputs consists of (dec_features, layer_state, dec_hidden, dec_attn)
     outputs: BaseModelOutputWithPast = self.model(
         input_ids=input_ids,
@@ -78,9 +66,6 @@ def cce_forward_multimodal(
         audio_embed_sizes=audio_embed_sizes,
         audio_attention_mask=audio_attention_mask,
         use_cache=use_cache,
-        output_attentions=output_attentions,
-        output_hidden_states=output_hidden_states,
-        cache_position=cache_position,
         **kwargs,
     )
 

--- a/cut_cross_entropy/transformers/qwen2_5_vl.py
+++ b/cut_cross_entropy/transformers/qwen2_5_vl.py
@@ -1,4 +1,4 @@
-"""Qwen2.5 VL CCE patch. Adapted from transformers v4.56.2"""
+"""Qwen2.5 VL CCE patch. Adapted from transformers 5.12.1."""
 
 # Copyright (C) 2024 Apple Inc. All Rights Reserved.
 
@@ -45,28 +45,16 @@ def cce_forward_multimodal(
     inputs_embeds: Optional[torch.FloatTensor] = None,
     labels: Optional[torch.LongTensor] = None,
     use_cache: Optional[bool] = None,
-    output_attentions: Optional[bool] = None,
-    output_hidden_states: Optional[bool] = None,
     pixel_values: Optional[torch.Tensor] = None,
     pixel_values_videos: Optional[torch.FloatTensor] = None,
     image_grid_thw: Optional[torch.LongTensor] = None,
     video_grid_thw: Optional[torch.LongTensor] = None,
-    rope_deltas: Optional[torch.LongTensor] = None,
-    cache_position: Optional[torch.LongTensor] = None,
+    mm_token_type_ids: Optional[torch.IntTensor] = None,
     second_per_grid_ts: Optional[torch.Tensor] = None,
     logits_to_keep: Union[int, torch.Tensor] = 0,
     **kwargs,
 ) -> Union[Tuple, Qwen2_5_VLCausalLMOutputWithPast]:
-    output_attentions = (
-        output_attentions if output_attentions is not None else self.config.output_attentions
-    )
-    output_hidden_states = (
-        output_hidden_states
-        if output_hidden_states is not None
-        else self.config.output_hidden_states
-    )
-
-    # Strip PEFT-injected return_dict so it doesn't collide with the explicit return_dict=True below.
+    # Strip PEFT-injected return_dict so it can't leak into self.model and force a tuple return.
     kwargs.pop("return_dict", None)
 
     outputs = self.model(
@@ -76,15 +64,12 @@ def cce_forward_multimodal(
         image_grid_thw=image_grid_thw,
         video_grid_thw=video_grid_thw,
         second_per_grid_ts=second_per_grid_ts,
+        mm_token_type_ids=mm_token_type_ids,
         position_ids=position_ids,
         attention_mask=attention_mask,
         past_key_values=past_key_values,
         inputs_embeds=inputs_embeds,
         use_cache=use_cache,
-        output_attentions=output_attentions,
-        output_hidden_states=output_hidden_states,
-        return_dict=True,
-        cache_position=cache_position,
         **kwargs,
     )
 

--- a/cut_cross_entropy/transformers/qwen2_vl.py
+++ b/cut_cross_entropy/transformers/qwen2_vl.py
@@ -45,26 +45,15 @@ def cce_forward_multimodal(
     inputs_embeds: Optional[torch.FloatTensor] = None,
     labels: Optional[torch.LongTensor] = None,
     use_cache: Optional[bool] = None,
-    output_attentions: Optional[bool] = None,
-    output_hidden_states: Optional[bool] = None,
     pixel_values: Optional[torch.Tensor] = None,
     pixel_values_videos: Optional[torch.FloatTensor] = None,
     image_grid_thw: Optional[torch.LongTensor] = None,
     video_grid_thw: Optional[torch.LongTensor] = None,
-    rope_deltas: Optional[torch.LongTensor] = None,
-    cache_position: Optional[torch.LongTensor] = None,
+    mm_token_type_ids: Optional[torch.IntTensor] = None,
+    logits_to_keep: Union[int, torch.Tensor] = 0,
     **kwargs,
 ) -> Union[Tuple, Qwen2VLCausalLMOutputWithPast]:
-    output_attentions = (
-        output_attentions if output_attentions is not None else self.config.output_attentions
-    )
-    output_hidden_states = (
-        output_hidden_states
-        if output_hidden_states is not None
-        else self.config.output_hidden_states
-    )
-
-    # Strip PEFT-injected return_dict so it doesn't collide with the explicit return_dict=True below.
+    # Strip PEFT-injected return_dict so it can't leak into self.model and force a tuple return.
     kwargs.pop("return_dict", None)
 
     outputs = self.model(
@@ -73,15 +62,12 @@ def cce_forward_multimodal(
         pixel_values_videos=pixel_values_videos,
         image_grid_thw=image_grid_thw,
         video_grid_thw=video_grid_thw,
+        mm_token_type_ids=mm_token_type_ids,
         position_ids=position_ids,
         attention_mask=attention_mask,
         past_key_values=past_key_values,
         inputs_embeds=inputs_embeds,
         use_cache=use_cache,
-        output_attentions=output_attentions,
-        output_hidden_states=output_hidden_states,
-        return_dict=True,
-        cache_position=cache_position,
         **kwargs,
     )
 
@@ -89,11 +75,18 @@ def cce_forward_multimodal(
     logits = None
     loss = None
 
+    # Only compute necessary logits, and do not upcast them to float if we are not computing the loss
+    slice_indices = (
+        slice(-logits_to_keep, None) if isinstance(logits_to_keep, int) else logits_to_keep
+    )
+
     if _PATCH_OPTS is not None and _PATCH_OPTS.use_lce(labels, self.training):
         assert labels is not None
-        loss = apply_lce(hidden_states, self.lm_head.weight, labels, _PATCH_OPTS, **kwargs)
+        loss = apply_lce(
+            hidden_states[:, slice_indices, :], self.lm_head.weight, labels, _PATCH_OPTS, **kwargs
+        )
     else:
-        logits = self.lm_head(hidden_states)
+        logits = self.lm_head(hidden_states[:, slice_indices, :])
 
         if labels is not None:
             loss = self.loss_function(

--- a/cut_cross_entropy/transformers/qwen3_moe.py
+++ b/cut_cross_entropy/transformers/qwen3_moe.py
@@ -1,4 +1,4 @@
-"""Qwen3 MoE CCE patch. Adapted from transformers v4.56.2."""
+"""Qwen3 MoE CCE patch. Adapted from transformers 5.12.1."""
 
 # Copyright (C) 2024 Apple Inc. All Rights Reserved.
 
@@ -48,7 +48,6 @@ def cce_forward(
     labels: Optional[torch.LongTensor] = None,
     use_cache: Optional[bool] = None,
     output_router_logits: Optional[bool] = None,
-    cache_position: Optional[torch.LongTensor] = None,
     logits_to_keep: Union[int, torch.Tensor] = 0,
     **kwargs,
 ) -> MoeCausalLMOutputWithPast:
@@ -67,7 +66,6 @@ def cce_forward(
         inputs_embeds=inputs_embeds,
         use_cache=use_cache,
         output_router_logits=output_router_logits,
-        cache_position=cache_position,
         **kwargs,
     )
 


### PR DESCRIPTION
There were missed patches. This catches that for parity #58 